### PR TITLE
Fix version download URL

### DIFF
--- a/src/KSPTextureLoader/KSPTextureLoader.csproj
+++ b/src/KSPTextureLoader/KSPTextureLoader.csproj
@@ -31,7 +31,7 @@
         <KSPVersionFile Include=".">
             <Destination>$(RepoRootPath)\GameData\KSPTextureLoader\KSPTextureLoader.version</Destination>
             <URL>https://github.com/Phantomical/KSPTextureLoader/releases/latest/download/KSPTextureLoader.version</URL>
-            <Download>https//github.com/Phantomical/KSPTextureLoader/releases</Download>
+            <Download>https://github.com/Phantomical/KSPTextureLoader/releases</Download>
         </KSPVersionFile>
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- fix the generated KSP-AVC DOWNLOAD URL so it uses https://

## Upstream check
- read README, CONTRIBUTING, CHANGELOG, LICENSE, and GitHub workflow metadata
- checked open issues: none
- checked open PRs: none

## Validation
- xmllint --noout src/KSPTextureLoader/KSPTextureLoader.csproj
- git diff --check
- verified the PR diff is limited to the missing colon in the generated DOWNLOAD URL
