### PR TITLE
Fix version download URL

### DIFF
--- a/src/KSPTextureLoader/KSPTextureLoader.csproj
+++ b/src/KSPTextureLoader/KSPTextureLoader.csproj
@@ -31,7 +31,7 @@
         <KSPVersionFile Include=".">
             <Destination>$(RepoRootPath)\GameData\KSPTextureLoader\KSPTextureLoader.version</Destination>
             <URL>https://github.com/Phantomical/KSPTextureLoader/releases/latest/download/KSPTextureLoader.version</URL>
-            <Download>https//github.com/Phantomical/KSPTextureLoader/releases</Download>
+            <Download>https://github.com/Phantomical/KSPTextureLoader/releases</Download>
         </KSPVersionFile>
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Fix the generated version/download metadata URL by adding the missing colon after `https`.
- Leave all KSP compatibility ranges and release/version values unchanged.

## Problem
The project metadata currently writes `https//github.com/Phantomical/KSPTextureLoader/releases`, which is not a valid HTTPS URL. Any generated `.version` metadata or downstream tool that displays the download link gets a broken release URL.

## Validation
- Diff inspection: one project-file URL string changed from `https//...` to `https://...`.
- Confirmed no compatibility ranges, release versions, package contents, or source behavior changed.